### PR TITLE
Fix Twitter and GitHub social links always displaying

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@ minima:
 
   # generate social links in footer
   social_links:
-    twitter: jekyllrb
-    github:  jekyll
+    # twitter: jekyllrb
+    # github:  jekyll
     # devto: jekyll
     # dribbble: jekyll
     # facebook: jekyll


### PR DESCRIPTION
The social links previously had a default value which meant even if not specified on your project, the Twitter and GitHub social links would still appear