### PR TITLE
Remove post-content margins

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -255,9 +255,6 @@
 .post-content {
   margin-bottom: $spacing-unit;
 
-  h1, h2, h3 { margin-top: $spacing-unit * 2 }
-  h4, h5, h6 { margin-top: $spacing-unit }
-
   h2 {
     @include relative-font-size(1.75);
 


### PR DESCRIPTION
Unecessary margins for headers made content harder to read and broke a few pages